### PR TITLE
Configure API Workflows

### DIFF
--- a/.github/workflows/api-doc.yml
+++ b/.github/workflows/api-doc.yml
@@ -20,18 +20,20 @@ env:
   API_TYPES: 'OAS'
   API_DIRECTORIES: 'server/src/main/resources/openapi'
   API_EXCLUDES: ''
-  OUTPUT_DIR: 'folio-api-docs'
-  AWS_S3_BUCKET: 'foliodocs'
+  OUTPUT_DIR: 'api-docs'
+  AWS_S3_BUCKET: 'indexdata-docs'
   AWS_S3_FOLDER: 'api'
   AWS_S3_REGION: 'us-east-1'
-  AWS_S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
-  AWS_S3_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+  AWS_S3_ACCESS_KEY_ID: ${{ secrets.INDEXDATA_S3_ACCESS_KEY_ID }}
+  AWS_S3_ACCESS_KEY: ${{ secrets.INDEXDATA_S3_SECRET_ACCESS_KEY }}
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main, master ]
     paths:
       - 'server/src/main/resources/openapi/**'
+      - 'descriptors/ModuleDescriptor-template.json'
     tags: '[vV][0-9]+.[0-9]+.[0-9]+*'
 
 jobs:

--- a/.github/workflows/api-lint.yml
+++ b/.github/workflows/api-lint.yml
@@ -27,6 +27,7 @@ env:
   API_WARNINGS: false
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - 'server/src/main/resources/openapi/**'

--- a/.github/workflows/api-schema-lint.yml
+++ b/.github/workflows/api-schema-lint.yml
@@ -17,6 +17,7 @@ env:
   API_EXCLUDES: ''
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - 'server/src/main/resources/openapi/**'

--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ API descriptions:
  * [OpenAPI](server/src/main/resources/openapi/reservoir.yaml)
  * [Schemas](server/src/main/resources/openapi/schemas/)
 
-Generated [API documentation](https://dev.folio.org/reference/api/#mod-reservoir).
+Generated [API documentation](https://s3.amazonaws.com/indexdata-docs/api/reservoir/reservoir.html).
 
 ### Code analysis
 

--- a/server/src/main/resources/openapi/reservoir.yaml
+++ b/server/src/main/resources/openapi/reservoir.yaml
@@ -998,3 +998,4 @@ components:
     errors:
       $ref: schemas/errors.json
 
+

--- a/server/src/main/resources/openapi/reservoir.yaml
+++ b/server/src/main/resources/openapi/reservoir.yaml
@@ -998,4 +998,3 @@ components:
     errors:
       $ref: schemas/errors.json
 
-


### PR DESCRIPTION
These were operating at the old folio-org/mod-reservoir repository. Re-configure the api-doc to publish to indexdata S3 space instead.