### PR TITLE
Remove encoding configuation for checkstyle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -347,7 +347,6 @@
         </dependencies>
         <configuration>
           <configLocation>checkstyle/folio_checks.xml</configLocation>
-          <encoding>UTF-8</encoding>
           <violationSeverity>warning</violationSeverity>
           <consoleOutput>false</consoleOutput>
           <failsOnError>true</failsOnError>


### PR DESCRIPTION
It was removed in version 3.2.0.