### PR TITLE
RSRVR-8 fix ingest gets duplicate key value violates constraint

### DIFF
--- a/server/src/main/java/com/indexdata/reservoir/server/Storage.java
+++ b/server/src/main/java/com/indexdata/reservoir/server/Storage.java
@@ -205,11 +205,11 @@ public class Storage {
     ).mapEmpty();
   }
 
-  Future<Boolean> upsertGlobalRecord(Vertx vertx, SqlConnection conn, String localIdentifier,
+  Future<Boolean> upsertGlobalRecord(Vertx vertx, String localIdentifier,
       SourceId sourceId, int sourceVersion, JsonObject payload, JsonArray matchKeyConfigs) {
 
     UUID startId = UUID.randomUUID();
-    return conn.preparedQuery(
+    return pool.preparedQuery(
             "INSERT INTO " + globalRecordTable
                 + " (id, local_id, source_id, source_version, payload)"
                 + " VALUES ($1, $2, $3, $4, $5)"
@@ -218,25 +218,27 @@ public class Storage {
                 + " RETURNING id"
         )
         .execute(Tuple.of(startId, localIdentifier, sourceId.toString(), sourceVersion, payload))
-        .map(rowSet -> rowSet.iterator().next().getUUID("id"))
-        .compose(id -> updateMatchKeyValues(vertx, conn, id, payload, matchKeyConfigs)
-            .map(x -> id.equals(startId)));
+        .map(rowSet -> rowSet.iterator().next().getUUID("id")
+      )
+      .compose(id -> updateMatchKeyValues(vertx, id, payload, matchKeyConfigs)
+        .map(x -> id.equals(startId)));
   }
 
-  Future<Void> deleteGlobalRecord(SqlConnection conn, String localIdentifier, SourceId sourceId,
-      int sourceVersion) {
-    String q = "UPDATE " + clusterMetaTable + " AS m"
-        + " SET datestamp = $4"
-        + " FROM " + globalRecordTable + ", " + clusterRecordTable + " AS r"
-        + " WHERE m.cluster_id = r.cluster_id AND r.record_id = id"
-        + " AND local_id = $1 AND source_id = $2 and source_version = $3";
-    return conn.preparedQuery(q)
-        .execute(Tuple.of(localIdentifier, sourceId.toString(), sourceVersion,
-            LocalDateTime.now(ZoneOffset.UTC)))
-        .compose(x -> conn.preparedQuery("DELETE FROM " + globalRecordTable
-                + " WHERE local_id = $1 AND source_id = $2 and source_version = $3")
-        .execute(Tuple.of(localIdentifier, sourceId.toString(), sourceVersion))
-        .mapEmpty());
+  Future<Void> deleteGlobalRecord(String localIdentifier, SourceId sourceId, int sourceVersion) {
+    return pool.withConnection(conn -> {
+      String q = "UPDATE " + clusterMetaTable + " AS m"
+            + " SET datestamp = $4"
+            + " FROM " + globalRecordTable + ", " + clusterRecordTable + " AS r"
+            + " WHERE m.cluster_id = r.cluster_id AND r.record_id = id"
+            + " AND local_id = $1 AND source_id = $2 and source_version = $3";
+      return conn.preparedQuery(q)
+              .execute(Tuple.of(localIdentifier, sourceId.toString(), sourceVersion,
+                  LocalDateTime.now(ZoneOffset.UTC)))
+              .compose(x -> conn.preparedQuery("DELETE FROM " + globalRecordTable
+                      + " WHERE local_id = $1 AND source_id = $2 and source_version = $3")
+              .execute(Tuple.of(localIdentifier, sourceId.toString(), sourceVersion))
+              .mapEmpty());
+    });
   }
 
   /**
@@ -248,41 +250,15 @@ public class Storage {
    * @param matchKeyConfigs match key configrations in use
    * @return async result with TRUE=inserted, FALSE=updated, null=deleted
    */
-  Future<Boolean> ingestGlobalRecord(Vertx vertx, SourceId sourceId, int sourceVersion,
-      JsonObject globalRecord, JsonArray matchKeyConfigs) {
-
-    return pool.withTransaction(conn ->
-            ingestGlobalRecord(vertx, conn, sourceId, sourceVersion,
-                globalRecord, matchKeyConfigs))
-        // addValuesToCluster may fail if for same new match key for parallel operations
-        // we recover just once for that. 2nd will find the new value for the one that
-        // succeeded.
-        .recover(x ->
-            pool.withTransaction(conn ->
-                ingestGlobalRecord(vertx, conn, sourceId, sourceVersion,
-                    globalRecord, matchKeyConfigs)));
-  }
-
-  /**
-   * Insert/update/delete global record.
-   * @param vertx Vert.x handle
-   * @param conn connection
-   * @param sourceId source identifier
-   * @param sourceVersion source version
-   * @param globalRecord global record JSON object
-   * @param matchKeyConfigs match key configrations in use
-   * @return async result with TRUE=inserted, FALSE=updated, null=deleted
-   */
-  Future<Boolean> ingestGlobalRecord(Vertx vertx, SqlConnection conn,
-      SourceId sourceId, int sourceVersion, JsonObject globalRecord,
-      JsonArray matchKeyConfigs) {
+  Future<Boolean> ingestGlobalRecord(Vertx vertx, SourceId sourceId,
+      int sourceVersion, JsonObject globalRecord, JsonArray matchKeyConfigs) {
 
     final String localIdentifier = globalRecord.getString("localId");
     if (localIdentifier == null) {
       return Future.failedFuture("localId required");
     }
     if (Boolean.TRUE.equals(globalRecord.getBoolean("delete"))) {
-      return deleteGlobalRecord(conn, localIdentifier, sourceId, sourceVersion)
+      return deleteGlobalRecord(localIdentifier, sourceId, sourceVersion)
           .map(x -> null);
     }
     final JsonObject payload = globalRecord.getJsonObject("payload");
@@ -292,18 +268,31 @@ public class Storage {
     if (sourceId == null) {
       return Future.failedFuture("sourceId required");
     }
-    return upsertGlobalRecord(vertx, conn, localIdentifier, sourceId,
+    return upsertGlobalRecord(vertx, localIdentifier, sourceId,
         sourceVersion, payload, matchKeyConfigs);
   }
 
-  Future<Void> updateMatchKeyValues(Vertx vertx, SqlConnection conn, UUID globalId,
+
+  Future<Void> updateMatchKeyValues(Vertx vertx, UUID globalId,
       JsonObject payload, JsonArray matchKeyConfigs) {
     List<Future<Void>> futures = new ArrayList<>(matchKeyConfigs.size());
     for (int i = 0; i < matchKeyConfigs.size(); i++) {
       JsonObject matchKeyConfig = matchKeyConfigs.getJsonObject(i);
-      futures.add(updateMatchKeyValues(vertx, conn, globalId, payload, matchKeyConfig));
+      futures.add(updateMatchKeyValues(vertx, globalId, payload, matchKeyConfig));
     }
     return GenericCompositeFuture.all(futures).mapEmpty();
+  }
+
+  Future<Void> updateMatchKeyValues(Vertx vertx, UUID globalId,
+      JsonObject payload, JsonObject matchKeyConfig) {
+    return pool
+      .withConnection(c ->
+          updateMatchKeyValues(vertx, c, globalId, payload, matchKeyConfig))
+      .recover(e -> {
+        log.info("update recover: {}", e.getMessage());
+        return pool.withConnection(c ->
+            updateMatchKeyValues(vertx, c, globalId, payload, matchKeyConfig));
+      });
   }
 
   Future<Void> updateMatchKeyValues(Vertx vertx, SqlConnection conn, UUID globalId,


### PR DESCRIPTION
The problem is happening because we use multiple match key configurations enabled on ingest and that there can be duplicate values.
The recovery was per record before. It is now per match key configuration.