### PR TITLE
Fix warnings on startup

### DIFF
--- a/Dockerfile-jit
+++ b/Dockerfile-jit
@@ -29,4 +29,4 @@ RUN mvn -B -DskipTests package
 
 EXPOSE 8081
 
-CMD ["sh", "-c", "/usr/lib64/graalvm/graalvm-java24/bin/java $JAVA_OPTS --enable-native-access=ALL-UNNAMED -jar server/target/mod-reservoir-server-fat.jar"]
+CMD ["sh", "-c", "/usr/lib64/graalvm/graalvm-java24/bin/java $JAVA_OPTS --sun-misc-unsafe-memory-access=allow --enable-native-access=ALL-UNNAMED -jar server/target/mod-reservoir-server-fat.jar"]


### PR DESCRIPTION
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by com.oracle.truffle.runtime.hotspot.HotSpotTruffleRuntime (file:/app/server/target/mod-reservoir-server-fat.jar)
WARNING: Please consider reporting this to the maintainers of class com.oracle.truffle.runtime.hotspot.HotSpotTruffleRuntime
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release