### PR TITLE
Cache maven repo as a docker layer

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -37,6 +37,13 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Set up GraalVM to restore Maven repository cache
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '24'
+          distribution: 'graalvm'
+          cache: 'maven'
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -55,14 +62,6 @@ jobs:
             type=ref,event=pr
             type=sha
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles(matrix.dockerfile) }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -76,5 +75,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             GIT_COMMIT=${{ github.sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
+            MAVEN_MOUNT_TYPE=bind
+            MAVEN_MOUNT_SOURCE=${{ env.HOME }}/.m2/repository
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/mvn-verify.yaml
+++ b/.github/workflows/mvn-verify.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1 # https://github.com/graalvm/setup-graalvm
         with:
-          java-version: '24.0.2'
+          java-version: '24'
           distribution: 'graalvm'
           cache: 'maven'
       - name: Show GraalVM and Java versions

--- a/Dockerfile-jit
+++ b/Dockerfile-jit
@@ -4,17 +4,20 @@ RUN microdnf install -y maven && microdnf clean all
 
 WORKDIR /app
 
+# GitHub actions does not persist cache mounts
+# we fetch maven deps first and rely on layer caching
+# simplify when this is fixed
 COPY pom.xml .
-COPY checkstyle/ checkstyle
+COPY client/pom.xml client/pom.xml
+COPY server/pom.xml server/pom.xml
+COPY util/pom.xml util/pom.xml
+RUN --mount=type=cache,sharing=shared,target=/root/.m2/repository mvn -B dependency:go-offline
 COPY client/ client
-COPY descriptors/ descriptors
-COPY js/ js
 COPY server/ server
 COPY util/ util
-COPY xsl/ xsl
+COPY descriptors/ descriptors
 ARG GIT_COMMIT=master
 RUN echo "git.commit.id=${GIT_COMMIT}" > server/src/main/resources/git.properties
-
 RUN --mount=type=cache,sharing=shared,target=/root/.m2/repository mvn -B -DskipTests -Pdocker-build package
 
 FROM container-registry.oracle.com/graalvm/jdk:24 AS slim

--- a/Dockerfile-jit
+++ b/Dockerfile-jit
@@ -2,23 +2,29 @@ FROM container-registry.oracle.com/graalvm/jdk:24 AS builder
 
 RUN microdnf install -y maven && microdnf clean all
 
+# Docker with GitHub Actions does not persist cache mounts
+# as a workaround, we fetch maven deps first and rely on layer caching
+# also, we allow overriding the mount to a BIND mount to inject graalvm-setup managed Maven cache
+ARG MAVEN_MOUNT_TYPE=cache
+ARG MAVEN_MOUNT_SOURCE=""
+
 WORKDIR /app
 
-# GitHub actions does not persist cache mounts
-# we fetch maven deps first and rely on layer caching
-# simplify when this is fixed
 COPY pom.xml .
 COPY client/pom.xml client/pom.xml
 COPY server/pom.xml server/pom.xml
 COPY util/pom.xml util/pom.xml
-RUN --mount=type=cache,sharing=shared,target=/root/.m2/repository mvn -B dependency:go-offline
-COPY client/ client
+
+RUN --mount=type=${MAVEN_MOUNT_TYPE},source=${MAVEN_MOUNT_SOURCE},target=/root/.m2/repository mvn -B dependency:go-offline
+
+COPY client/ client/
 COPY server/ server
 COPY util/ util
 COPY descriptors/ descriptors
 ARG GIT_COMMIT=master
 RUN echo "git.commit.id=${GIT_COMMIT}" > server/src/main/resources/git.properties
-RUN --mount=type=cache,sharing=shared,target=/root/.m2/repository mvn -B -DskipTests -Pdocker-build package
+
+RUN --mount=type=${MAVEN_MOUNT_TYPE},source=${MAVEN_MOUNT_SOURCE},target=/root/.m2/repository mvn -B -DskipTests -Pdocker-build package
 
 FROM container-registry.oracle.com/graalvm/jdk:24 AS slim
 

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,20 @@
   </dependencyManagement>
   <profiles>
     <profile>
+      <id>docker-build</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-checkstyle-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>apple-silicon</id>
       <activation>
         <os>


### PR DESCRIPTION
Maven repo is not getting restored correctly in GHA because Docker doesn't persist cache mounts (https://github.com/moby/buildkit/issues/1512).  This workaround relies on the standard layer caching and fetching maven deps before the build. 
Additionally, in the CI we use the standard bind mount and re-use the maven cache from the `graalvm-setup` action.